### PR TITLE
Add feature register service #4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,12 +2,12 @@ organization := "com.lightbend.lagom"
 
 name := "lagom-service-locator-consul"
 
-version := "1.0.0-SNAPSHOT"
+version := "1.0.1-SNAPSHOT"
 
 scalaVersion := "2.11.8"
 
 libraryDependencies ++= Seq(
-  "com.lightbend.lagom" %% "lagom-javadsl-api" % "1.0.0-M1",
+  "com.lightbend.lagom" %% "lagom-javadsl-api" % "1.2.0",
   "com.ecwid.consul"     % "consul-api"        % "1.1.10",
   "org.scalatest"       %% "scalatest"         % "2.2.4" % Test
 )

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,10 +1,10 @@
 #############################################################
-# Lagom Service Locator for ZooKeeper Reference Config File #
+# Lagom Service Locator for Consul Reference Config File    #
 #############################################################
 
 # This is the reference config file that contains all the default settings.
 # Make your edits/overrides in your application.conf.
 
-# Enables the `ConsulServiceLocatorModule` to register the `ZooKeeperServiceLocator`.
-# The `ZooKeeperServiceLocator` implements Lagom's ServiceLocator
+# Enables the `ConsulServiceLocatorModule` to register the `ConsulServiceLocator`.
+# The `ConsulServiceLocator` implements Lagom's ServiceLocator
 play.modules.enabled += "com.lightbend.lagom.discovery.consul.ConsulServiceLocatorModule"

--- a/src/main/scala/com/lightbend/lagom/discovery/consul/ConsulConfig.scala
+++ b/src/main/scala/com/lightbend/lagom/discovery/consul/ConsulConfig.scala
@@ -11,16 +11,26 @@ trait ConsulConfig {
   def agentPort: Int
   def scheme: String
   def routingPolicy: RoutingPolicy
+  def serviceName: String
+  def serviceId: String
+  def serviceAddress: String
+  def servicePort: Int
 }
 
 object ConsulConfig {
+
   @Singleton
-  class ConsulConfigImpl @Inject() (config: Configuration) extends ConsulConfig {
+  class ConsulConfigImpl @Inject()(config: Configuration) extends ConsulConfig {
     override val agentHostname = config.getString("lagom.discovery.consul.agent-hostname").get
     override val agentPort = config.getInt("lagom.discovery.consul.agent-port").get
     override val scheme = config.getString("lagom.discovery.consul.uri-scheme").get
     override val routingPolicy = RoutingPolicy(config.getString("lagom.discovery.consul.routing-policy").get)
+    override val serviceName = config.getString("lagom.register.serviceName").get
+    override val serviceId = config.getString("lagom.register.serviceId").get
+    override val serviceAddress = config.getString("lagom.register.serviceAddress").get
+    override val servicePort = config.getInt("lagom.register.servicePort").get
   }
+
 }
 
 object RoutingPolicy {
@@ -31,7 +41,11 @@ object RoutingPolicy {
     case unknown => throw new BadValue("lagom.discovery.consul.routing-policy", s"[$unknown] is not a valid routing algorithm")
   }
 }
+
 sealed trait RoutingPolicy
+
 case object First extends RoutingPolicy
+
 case object Random extends RoutingPolicy
+
 case object RoundRobin extends RoutingPolicy

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -7,4 +7,12 @@ lagom {
       routing-policy = "round-robin" # valid routing policies: first, random, round-robin
     }
   }
+  register {
+    serviceName = ""
+    serviceId = ""
+    serviceAddress = ""
+    servicePort = 0
+
+
+  }
 }


### PR DESCRIPTION
This PR try to implement issue **Register service automatically** #4.
In the serviceLocatorModule's construtor, I added the registration procedure of the service.
This registration is based on some entries stored in reference.conf file.
In this way, the developer can keep focus on the service implementation and not on how manage service registering
